### PR TITLE
Add custom options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,22 @@ Methods
 ### add(magnet, dlpath, callback) or add(file, dlpath, callback) or add(url, dlpath, callback)
 
 Call add with a magnet link to automatically post the add request to your deluge-web server. If successful, it will add and start downloading without further action.
-You can also use a direct url to a torrent file, deluge will download the file and star the download
+You can also use a direct url to a torrent file, deluge will download the file and start the download.
+It is also possible to substitute dlpath with your own options by providing a json object instead.
+Default options are:
+```json
+{
+  file_priorities: [],
+  add_paused: false,
+  compact_allocation: true,
+  download_location: dlPath,
+  max_connections: -1,
+  max_download_speed: -1,
+  max_upload_slots: -1,
+  max_upload_speed: -1,
+  prioritize_first_last_pieces: false
+}
+```
 
 ### getHosts(callback)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Call add with a magnet link to automatically post the add request to your deluge
 You can also use a direct url to a torrent file, deluge will download the file and start the download.
 It is also possible to substitute dlpath with your own options by providing a json object instead.
 Default options are:
-```json
+```
 {
   file_priorities: [],
   add_paused: false,

--- a/index.js
+++ b/index.js
@@ -234,21 +234,24 @@
 
     function addTorrent(magnet, dlPath, callback) {
         console.log("Adding: " + magnet);
+        var config = {
+            file_priorities: [],
+            add_paused: false,
+            compact_allocation: true,
+            download_location: dlPath,
+            max_connections: -1,
+            max_download_speed: -1,
+            max_upload_slots: -1,
+            max_upload_speed: -1,
+            prioritize_first_last_pieces: false
+        }
+        var isObj = function (obj) {return obj !== undefined && obj !== null && obj.constructor == Object; }
+        dlPath = (isObj(dlPath) ? dlPath : config);
         post({
             method: 'web.add_torrents',
             params: [[{
                 path: magnet,
-                options: {
-                    file_priorities: [],
-                    add_paused: false,
-                    compact_allocation: true,
-                    download_location: dlPath,
-                    max_connections: -1,
-                    max_download_speed: -1,
-                    max_upload_slots: -1,
-                    max_upload_speed: -1,
-                    prioritize_first_last_pieces: false
-                }
+                options: config
             }]]
         }, callback);
     }

--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@
             prioritize_first_last_pieces: false
         }
         var isObj = function (obj) {return obj !== undefined && obj !== null && obj.constructor == Object; }
-        dlPath = (isObj(dlPath) ? dlPath : config);
+        config = (isObj(dlPath) ? dlPath : config);
         post({
             method: 'web.add_torrents',
             params: [[{


### PR DESCRIPTION
Made it possible to add custom options when adding a torrent.
I wanted to add some options, namely
```
move_completed:true,
move_completed_path:"<insertpathhere>",
```
for more control over where to store the file(s) once the download is completed.
This is because my default download path is set to a SSD and then the files are moved to a large HDD.

Thought i would share my implementation as others may have the same need.